### PR TITLE
Add /blog_posts api endpoint to create new blogposts

### DIFF
--- a/app/Controllers/Http/BlogPostController.js
+++ b/app/Controllers/Http/BlogPostController.js
@@ -1,0 +1,37 @@
+const BlogPost = use('App/Models/BlogPost')
+
+class BlogPostController {
+    async index() {
+        const blogPosts = await BlogPost.getAll()
+        return blogPosts
+    }
+
+    async show({ params }) {
+        const blogPost = await BlogPost.getOneById(params.id)
+        return blogPost
+    }
+
+    async store({ request, response, auth }) {
+        const blogPostData = request.only(['post_title', 'post_body'])
+
+        blogPostData.user_id = auth.user.id
+
+        const newBlogPost = await BlogPost.createAndSave(blogPostData)
+
+        if (newBlogPost) {
+            return response.status(201).json(newBlogPost)
+        }
+    }
+
+    async update({ params, request, response }) {
+        const blogPostId = params.id
+
+        const dataToUpdate = request.only(['post_title', 'post_body'])
+
+        const blogPost = await BlogPost.updateById(blogPostId, dataToUpdate)
+
+        response.status(200).json(blogPost)
+    }
+}
+
+module.exports = BlogPostController

--- a/app/Models/BlogPost.js
+++ b/app/Models/BlogPost.js
@@ -1,0 +1,41 @@
+/** @type {typeof import('@adonisjs/lucid/src/Lucid/Model')} */
+const Model = use('Model')
+
+class BlogPost extends Model {
+    user() {
+        return this.belongsTo('App/Models/User')
+    }
+
+    static createAndSave(blogPostData) {
+        return BlogPost.create(blogPostData)
+    }
+
+    static getAll() {
+        return BlogPost.query()
+            .with('user', builder => {
+                builder.select(['id', 'name'])
+            })
+            .fetch()
+    }
+
+    static async getOneById(id) {
+        const blogPost = await BlogPost.findOrFail(id)
+        await blogPost.load('user', builder => {
+            builder.select(['id', 'name'])
+        })
+
+        return blogPost
+    }
+
+    static async updateById(id, dataToUpdate) {
+        const blogPost = await BlogPost.findOrFail(id)
+
+        blogPost.merge(dataToUpdate)
+
+        await blogPost.save()
+
+        return blogPost
+    }
+}
+
+module.exports = BlogPost

--- a/app/Models/User.js
+++ b/app/Models/User.js
@@ -22,6 +22,10 @@ class User extends Model {
     events() {
         return this.hasMany('App/Models/Event')
     }
+
+    blogPosts() {
+        return this.hasMany('App/Models/BlogPost')
+    }
 }
 
 module.exports = User

--- a/app/Validators/BlogPost.js
+++ b/app/Validators/BlogPost.js
@@ -1,0 +1,20 @@
+const Antl = use('Antl')
+
+class BlogPost {
+    get validateAll() {
+        return true
+    }
+
+    get rules() {
+        return {
+            post_title: 'required',
+            post_body: 'required',
+        }
+    }
+
+    get messages() {
+        return Antl.list('validation')
+    }
+}
+
+module.exports = BlogPost

--- a/database/factory.js
+++ b/database/factory.js
@@ -48,3 +48,11 @@ Factory.blueprint('App/Models/Event', (faker, i, data = {}) => {
         ...data,
     }
 })
+
+Factory.blueprint('App/Models/BlogPost', (faker, i, data = {}) => {
+    return {
+        post_title: faker.sentence({ words: 4 }),
+        post_body: faker.paragraph(),
+        ...data,
+    }
+})

--- a/database/migrations/1579724239210_blog_post_schema.js
+++ b/database/migrations/1579724239210_blog_post_schema.js
@@ -1,0 +1,26 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema')
+
+class BlogPostSchema extends Schema {
+    up() {
+        this.create('blog_posts', table => {
+            table.increments()
+            table
+                .integer('user_id')
+                .unsigned()
+                .references('id')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .onUpdate('CASCADE')
+            table.string('post_title').notNullable()
+            table.text('post_body').notNullable()
+            table.timestamps()
+        })
+    }
+
+    down() {
+        this.drop('blog_posts')
+    }
+}
+
+module.exports = BlogPostSchema

--- a/start/routes.js
+++ b/start/routes.js
@@ -26,3 +26,12 @@ Route.group(() => {
     Route.get('/events/:id', 'EventController.show')
     Route.post('/events', 'EventController.store').validator('Event')
 }).middleware('auth')
+
+Route.group(() => {
+    Route.get('/blog_posts', 'BlogPostController.index')
+    Route.get('/blog_posts/:id', 'BlogPostController.show')
+    Route.post('/blog_posts', 'BlogPostController.store').validator('BlogPost')
+    Route.put('/blog_posts/:id', 'BlogPostController.update').validator(
+        'BlogPost'
+    )
+}).middleware('auth')

--- a/test/functional/blogposts.spec.js
+++ b/test/functional/blogposts.spec.js
@@ -1,0 +1,103 @@
+const { test, trait } = use('Test/Suite')('Blog Posts')
+
+/** @type {typeof import('@adonisjs/lucid/src/Lucid/Model')} */
+const Factory = use('Factory')
+
+trait('Test/ApiClient')
+trait('Auth/Client')
+trait('DatabaseTransactions')
+
+const BLOG_POSTS_ENDPOINT = '/blog_posts'
+
+test('it should be able to create new blog posts', async ({
+    assert,
+    client,
+}) => {
+    const user = await Factory.model('App/Models/User').create()
+
+    const blogPostData = {
+        post_title: 'My awesome test post.',
+        post_body: 'My awesome post content, lots of usefull stuff here.',
+    }
+
+    const response = await client
+        .post(BLOG_POSTS_ENDPOINT)
+        .loginVia(user, 'jwt')
+        .send(blogPostData)
+        .end()
+
+    response.assertStatus(201)
+    assert.exists(response.body)
+    response.assertJSONSubset(blogPostData)
+})
+
+test('it should be able to list blog posts in the database', async ({
+    assert,
+    client,
+}) => {
+    const user = await Factory.model('App/Models/User').create()
+    const blogPost = await Factory.model('App/Models/BlogPost').make({
+        user_id: user.id,
+    })
+
+    await user.blogPosts().save(blogPost)
+
+    const response = await client
+        .get(BLOG_POSTS_ENDPOINT)
+        .loginVia(user, 'jwt')
+        .end()
+
+    response.assertStatus(200)
+    assert.equal(response.body[0].post_title, blogPost.post_title)
+    assert.equal(response.body[0].post_body, blogPost.post_body)
+    assert.equal(response.body[0].user.id, blogPost.user_id)
+})
+
+test('it should be able to show a single blog post', async ({
+    assert,
+    client,
+}) => {
+    const user = await Factory.model('App/Models/User').create()
+    const blogPost = await Factory.model('App/Models/BlogPost').create({
+        user_id: user.id,
+    })
+
+    await user.blogPosts().save(blogPost)
+
+    const response = await client
+        .get(`${BLOG_POSTS_ENDPOINT}/${blogPost.id}`)
+        .loginVia(user, 'jwt')
+        .end()
+
+    response.assertStatus(200)
+    assert.equal(response.body.post_title, blogPost.post_title)
+    assert.equal(response.body.post_body, blogPost.post_body)
+    assert.equal(response.body.user.id, blogPost.user_id)
+})
+
+test('it should be able to edit a blog post in the database', async ({
+    client,
+}) => {
+    const user = await Factory.model('App/Models/User').create()
+    const blogPost = await Factory.model('App/Models/BlogPost').create({
+        user_id: user.id,
+    })
+
+    await user.blogPosts().save(blogPost)
+
+    const updatedPost = {
+        post_title: 'My updated post.',
+        post_body: 'My updated text... Lot of words here....',
+    }
+
+    const response = await client
+        .put(`${BLOG_POSTS_ENDPOINT}/${blogPost.id}`)
+        .loginVia(user, 'jwt')
+        .send(updatedPost)
+        .end()
+
+    await blogPost.reload()
+
+    response.assertStatus(200)
+    response.assertJSONSubset(updatedPost)
+})


### PR DESCRIPTION
This PR is meant to close issue #7 and it creates a new endpoint: /blog_posts
This endpoint has an index route (list all), a show route (show by id), a create route and edit route.